### PR TITLE
Convert types to object instead of array

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@ export default function createModule(name, initial, handler) {
       }),
     {}
   );
-  const types = Object.keys(handler).map(key => `${name}/${key}`);
+  const types = Object.keys(handler).reduce((acc, key) => Object.assign({}, acc, {[key]: `${name}/${key}`}), {});
   return { reducer, actions, types };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-create-module",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A single function that returns a reducer, action creators, and action types",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
In this way we can just simply use as: `types.myActionName`